### PR TITLE
Add a resources index

### DIFF
--- a/RESOURCES.md
+++ b/RESOURCES.md
@@ -1,0 +1,37 @@
+Forked from [NLP-Papers](https://github.com/llhthinker/NLP-Papers)
+# NLP-Resources
+- [Distributed Word Representations](#distributed-word-representations)
+- [Distributed Sentence Representations](#distributed-sentence-representations)
+- [Entity Recognition (Sequence Tagging)](#entity-recognition)
+- [Language Model (LM for pre-training)](#language-model)
+- [Machine Translation](#machine-translation)
+- [Question Answering (Machine Reading Comprehension)](#question-answering)
+- [Recommendation Systems](#recommendation-systems)
+- [Relation Extraction](#relation-extraction)
+- [Sentences Matching (Natural Language Inference/Textual Entailment)](#sentences-matching)
+- [Text Classification (Sentiment Classification)](#text-classification)
+- [Materials/Toolkits](#materials)
+
+## Papers and Articles
+### Distributed Word Representations
+
+### Distributed Sentence Representations
+
+### Entity Recognition
+
+### Language Model
+
+### Machine Translation
+
+### Question Answering
+
+### Recommendation Systems
+  
+### Relation Extraction
+  
+### Sentences Matching
+  
+### Text Classification
+
+### Materials
+

--- a/RESOURCES.md
+++ b/RESOURCES.md
@@ -1,5 +1,5 @@
 Inspired from [NLP-Papers](https://github.com/llhthinker/NLP-Papers)
-# NLP-Resources
+# Index
 - [Distributed Word Representations](#distributed-word-representations)
 - [Distributed Sentence Representations](#distributed-sentence-representations)
 - [Entity Recognition (Sequence Tagging)](#entity-recognition)
@@ -11,8 +11,9 @@ Inspired from [NLP-Papers](https://github.com/llhthinker/NLP-Papers)
 - [Sentences Matching (Natural Language Inference/Textual Entailment)](#sentences-matching)
 - [Text Classification (Sentiment Classification)](#text-classification)
 - [Materials/Toolkits](#materials)
+- [Regularization Techniques](#regularization)
 
-## Papers and Articles
+## Resources
 
 ### Distributed Word Representations
 
@@ -36,3 +37,5 @@ Inspired from [NLP-Papers](https://github.com/llhthinker/NLP-Papers)
 
 ### Materials
 
+### Regularization
+  - **[:newspaper: educational]** [Analysis of Dropout](https://pgaleone.eu/deep-learning/regularization/2017/01/10/anaysis-of-dropout/)

--- a/RESOURCES.md
+++ b/RESOURCES.md
@@ -1,4 +1,4 @@
-Forked from [NLP-Papers](https://github.com/llhthinker/NLP-Papers)
+Inspired from [NLP-Papers](https://github.com/llhthinker/NLP-Papers)
 # NLP-Resources
 - [Distributed Word Representations](#distributed-word-representations)
 - [Distributed Sentence Representations](#distributed-sentence-representations)
@@ -13,6 +13,7 @@ Forked from [NLP-Papers](https://github.com/llhthinker/NLP-Papers)
 - [Materials/Toolkits](#materials)
 
 ## Papers and Articles
+
 ### Distributed Word Representations
 
 ### Distributed Sentence Representations
@@ -20,7 +21,7 @@ Forked from [NLP-Papers](https://github.com/llhthinker/NLP-Papers)
 ### Entity Recognition
 
 ### Language Model
-
+  - **[:eyeglasses: analysis]** [BERT Rediscovers the Classical NLP Pipeline](https://github.com/eg-nlp-community/nlp-reading-group/issues/2)
 ### Machine Translation
 
 ### Question Answering


### PR DESCRIPTION
This PR adds an additional file to the repository that includes an index that should eventually contain all the papers and any other resources that are shared on slack or during the discussions, the motive behind this index is the following : 

1- By regularly updating this index, new-comers will still be able to benefit from the high quality resources that we previously shared during our discussions.

2- It will provide all the community members with a proper mean for sharing valuable resources and easy access to them. Searching slack for a resource someone posted a while ago is too much of a hassle, and the index is meant to solve that. 

I have managed to put up a basic index file and added two resources to it for showcasing purposes, let me know if you think this addition is valid since it will still probably need some tweaking (specially the categorization part). 
